### PR TITLE
Able to search for 4yp based on given user_id, instead of searching b…

### DIFF
--- a/back_end/src/apis/four_year_plan.py
+++ b/back_end/src/apis/four_year_plan.py
@@ -163,6 +163,8 @@ def get_entries():
 @login_required
 def get_plan_by_user():
     user_id = current_user.id
+    if request.args.get('user_id'):
+        user_id = request.args.get('user_id')
     plan = FourYearPlan.get_plan_by_user(user_id=user_id)
     plan = list(map(lambda x: x.to_json(), plan))
     return jsonify({'reason': 'success', 'result': plan}), 200
@@ -172,6 +174,8 @@ def get_plan_by_user():
 @login_required
 def get_formatted_plan_by_user():
     user_id = current_user.id
+    if request.args.get('user_id'):
+        user_id = request.args.get('user_id')
     plan = FourYearPlan.get_plan_by_user(user_id=user_id)
     plan = list(map(lambda x: x.to_json(), plan))
     # Now we call helper function


### PR DESCRIPTION
…ased on current logged in user

#PR: 
Related Issues: Tag your issue on the right panel of github page after you submit your PR
Author @Benson272 
Reviewers: Request reviewer on the right panel of the current page
Lable: Set lable to backend on the right panel of the current page

Description: We are now able to get a person's plan based on their user_id, not just getting the plan of the user currently logged in.

Added Behavior: Could be optional. Just describe it

Changed Behavior: Could be optional. Just describe it
